### PR TITLE
[ADD] change to newer numpy version directives

### DIFF
--- a/pyArgus/beamform.py
+++ b/pyArgus/beamform.py
@@ -80,11 +80,10 @@ def fixed_max_sir_beamform(angles, constraints, array_alignment):
         A[:, k] = np.exp(array_alignment*1j*2*np.pi*np.cos(np.deg2rad(angles[k])))
     print(A)
     # Calculate coefficient vector
-    A = np.matrix(A) # convert to matrix
-    u = np.matrix(constraints) # convert to vector
-    A_inv = A.getI() # invert A matrix
-    w_max_sir = (u.getT() * A_inv).getH() # solve linear equation
-    w_max_sir = w_max_sir.getA()[:,0]  # conver to numpy array
+    A = np.array(A) # convert to matrix
+    u = np.array(constraints) # convert to vector
+    A_inv = lin.inv(A) # invert A matrix
+    w_max_sir = np.conj((u.T @ A_inv).T) # solve linear equation
 
     return w_max_sir
 
@@ -131,20 +130,20 @@ def Goadar_max_sir_beamform(angles, U, array_alignment):
     for k in range(noc):        
         A[:, k] = np.exp(array_alignment*1j*2*np.pi*np.cos(np.deg2rad(angles[k])))
        
-    A = np.matrix(A) # Change to matrix object
-    U = np.matrix(U) # Change to matrix object
+    A = np.array(A) # Change to matrix object
+    U = np.array(U) # Change to matrix object
     
-    I = np.matrix(np.eye(N)) # Identity matrix
+    I = np.array(np.eye(N)) # Identity matrix
     
     sigmaN2 = 0.001
-    aux    = (A*A.getH() + sigmaN2 * I)
-    aux_inv = aux.getI()
+    aux    = (A@np.conj(A.T) + sigmaN2 * I)
+    aux_inv = lin.inv(aux)
     
-    w_Godara_maxsir = U*(A.getH() * aux_inv)
+    w_Godara_maxsir = U@(np.conj(A.T) @ aux_inv)
     
-    w_Godara_maxsir = w_Godara_maxsir.getH()
+    w_Godara_maxsir = np.conj(w_Godara_maxsir.T)
 
-    return w_Godara_maxsir.getA()[:,0]
+    return w_Godara_maxsir
     
 
 
@@ -180,11 +179,11 @@ def MSINR_beamform(Rss,Rnunu,aS = None):
     # -- Calculation --    
         
     # Convert input arrays to matrix form    
-    Rss =  np.matrix(Rss)  
-    Rnunu =  np.matrix(Rnunu)  
+    Rss =  np.array(Rss)  
+    Rnunu =  np.array(Rnunu)  
     
     # Calcaulating product matrix
-    prodMatrix = Rnunu.getI() * Rss
+    prodMatrix = lin.inv(Rnunu) @ Rss
     
     #calcaulte eigenvectors and eigenvalues
     w,v = np.linalg.eig(prodMatrix)
@@ -195,7 +194,7 @@ def MSINR_beamform(Rss,Rnunu,aS = None):
     # eigenvector belongs to the maximum eigenvalue is equal to the optimal solution
     w_msinr = v[:,np.argmax(np.abs(w))]
        
-    return maxEigenVal, w_msinr.getA()[:,0]
+    return maxEigenVal, w_msinr
         
     
 
@@ -252,14 +251,14 @@ def optimal_Wiener_beamform(Rnunu, aS):
     
     # -- Calculation --    
     # Change Rnunu array to matrix form
-    Rnunu = np.matrix(Rnunu) # noise+interference autocorrelation matrix
+    Rnunu = np.array(Rnunu) # noise+interference autocorrelation matrix
     
     # Change array response vector to matrix form
-    aS =  np.matrix(aS)
+    aS =  np.array(aS)
     
-    w_msinr = Rnunu.getI() * aS    
+    w_msinr = lin.inv(Rnunu) @ aS    
 
-    return w_msinr.getA()[:,0]
+    return w_msinr
 
 
 def MMSE_beamform(received_signal, desired_signal):
@@ -366,12 +365,12 @@ def peigen_bemform(Rnunu, aS, peigs):
     
     # -- Calculation --    
     # Change Rnunu array to matrix form
-    Rnunu = np.matrix(Rnunu) # noise+interference autocorrelation matrix
+    Rnunu = np.array(Rnunu) # noise+interference autocorrelation matrix
     
     # Change array response vector to matrix form
-    aS =  np.matrix(aS)
+    aS =  np.array(aS)
     
-    I = np.matrix(np.eye(M))
+    I = np.array(np.eye(M))
     
     # Determine eigenvectors and eigenvalues
     sigmai, vi = lin.eig(Rnunu)
@@ -384,13 +383,13 @@ def peigen_bemform(Rnunu, aS, peigs):
     
     # Generate clutter subspace matrix
     clutter_dim = peigs
-    q = np.matrix(np.zeros((M, clutter_dim),dtype=complex))
+    q = np.array(np.zeros((M, clutter_dim),dtype=complex))
     for i in range(clutter_dim):             
         q[:,i] = eig_array[i][1]    
     
-    w_pe = (I-q*q.getH()) * aS  # Noise subspace
+    w_pe = (I-q@np.conj(q.T)) @ aS  # Noise subspace
     
-    return w_pe.getA()[:, 0]
+    return w_pe
     
 def estimate_corr_matrix(X, imp="mem_eff"):
     """

--- a/pyArgus/directionEstimation.py
+++ b/pyArgus/directionEstimation.py
@@ -295,19 +295,19 @@ def DOA_LPM(R, scanning_vectors, element_select, angle_resolution = 1):
         print("ERROR: Signular matrix")
         return -3, -3
 
-    R_inv = np.matrix(R_inv)
+    R_inv = np.array(R_inv)
     M = np.size(scanning_vectors,0)
     
     # Create element selector vector
     u = np.zeros(M,dtype=complex)
     u[element_select] = 1
-    u = np.matrix(u).getT()        
+    u = np.array(u).T       
     
     theta_index=0
     for i in range(np.size(scanning_vectors,1)):             
         S_theta_ = scanning_vectors[:, i]
-        S_theta_ = np.matrix(S_theta_).getT() 
-        PLP[theta_index]=  np.real(u.getH() * R_inv * u) / np.abs(u.getH()* R_inv * S_theta_)**2            
+        S_theta_ = np.array(S_theta_).T
+        PLP[theta_index]=  np.real(np.conj(u.T) @ R_inv @ u) / np.abs(np.conj(u.T)@ R_inv @ S_theta_)**2            
         theta_index += 1   
  
     return PLP
@@ -380,13 +380,13 @@ def DOA_MUSIC(R, scanning_vectors, signal_dimension, angle_resolution = 1):
     for i in range(noise_dimension):     
         E[:,i] = eig_array[i][1]     
         
-    E = np.matrix(E)    
+    E = np.array(E)    
     
     theta_index=0
     for i in range(np.size(scanning_vectors, 1)):             
         S_theta_ = scanning_vectors[:, i]
-        S_theta_  = np.matrix(S_theta_).getT() 
-        ADORT[theta_index]=  1/np.abs(S_theta_.getH()*(E*E.getH())*S_theta_)
+        S_theta_  = np.array(S_theta_).T
+        ADORT[theta_index]=  1/np.abs(np.conj(S_theta_.T)@(E@np.conj(E.T))@S_theta_)
         theta_index += 1
          
     return ADORT
@@ -478,7 +478,7 @@ def DOAMD_MUSIC(R, array_alignment, signal_dimension, coherent_sources=2, angle_
     for i in range(noise_dimension):     
         E[:,i] = eig_array[i][1]
            
-    E = np.matrix(E)   
+    E = np.array(E)   
     
     theta_index  = 0
     theta2_index = 0
@@ -489,8 +489,8 @@ def DOAMD_MUSIC(R, array_alignment, signal_dimension, coherent_sources=2, angle_
         theta2_index=0
         for theta2 in incident_angles[0:theta_index]:            
             S_theta_2_ = np.exp(array_alignment*1j*2*np.pi*np.cos(np.radians(theta2))) # Scanning vector                                  
-            a = np.matrix(S_theta_+S_theta_2_).getT() # Spatial signiture vector
-            ADORT[theta_index,theta2_index]=  np.real(1/np.abs(a.getH()*(E*E.getH())*a))            
+            a = np.array(S_theta_+S_theta_2_).T # Spatial signiture vector
+            ADORT[theta_index,theta2_index]=  np.real(1/np.abs(np.conj(a.T)@(E@np.conj(E.T))@a))            
             theta2_index += 1
         theta_index += 1
     
@@ -637,12 +637,12 @@ def forward_backward_avg(R):
     
     # --> Calculation
     M = np.size(R, 0)  # Number of antenna elements
-    R = np.matrix(R)
+    R = np.array(R)
 
     # Create exchange matrix
     J = np.eye(M)
     J = np.fliplr(J) 
-    J = np.matrix(J)
+    J = np.array(J)
     
     R_fb = 0.5 * (R + J*np.conjugate(R)*J)
 

--- a/pyArgus/directionEstimation.py
+++ b/pyArgus/directionEstimation.py
@@ -644,7 +644,7 @@ def forward_backward_avg(R):
     J = np.fliplr(J) 
     J = np.array(J)
     
-    R_fb = 0.5 * (R + J*np.conjugate(R)*J)
+    R_fb = 0.5 * (R + J@np.conjugate(R)@J)
 
     return np.array(R_fb)
          


### PR DESCRIPTION
A.getH() → np.conj(A.T)
A.getI() → np.linalg.inv(A)
A.getT() → A.T
A.getA() (Convert to array) → No longer needed.

np.matrix -> np.array